### PR TITLE
fix form submission bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,7 @@ const GravityFormForm = ({
                         errorCallback({ id, values, error: data, reset })
                 }
 
-                if (status === 'success') {
+                if (status === 'success' && returnData?.is_valid === true) {
                     const { confirmation_message, confirmation_type, confirmation_redirect } = data?.data
 
                     if( confirmation_type === "redirect" && confirmation_redirect){


### PR DESCRIPTION
On occasion, the form is appearing like it has submitted and showing the thank you message. However, no data is saved on the backend. It appears to happen when there are form field errors(validation messages) but the fetch call itself is successful so the status is "success" but the is_valid is still false. Adding the second check of is_valid===true to fix bug and keep the form showing with it's error messages